### PR TITLE
feat(game): add miner orders and visuals

### DIFF
--- a/docs/bitcoin-mining-game-design.md
+++ b/docs/bitcoin-mining-game-design.md
@@ -18,27 +18,31 @@ Reference: brainstorm notes in `docs/bitcoin-mining-rules-exploration.md`.
   - Players earn BTC by constructing mining stations on their properties and collecting payouts.
 
 ## Game Setup & Start
-- Each player starts with 1,200,000 fiat tokens.
-- Each player starts with no BTC, no properties, and no mining stations.
-- Cycle 1 payments are fiat-only; cycle 2+ allows BTC payments at a 10% discount.
+- Each player starts with 1,000,000 fiat tokens and 1 BTC.
+- Each player starts with no properties and no mining stations.
+- Fiat and BTC payments are allowed in all cycles; BTC payments are priced at a 10% discount using the base (cycle 1) fiat price.
+- Exchange rate reference for UI: 1 BTC = 100,000 fiat.
 
 ## Buying Properties & Mining Rigs
 - Properties are bought with fiat; regular properties can host up to 4 miner batches.
 - Property prices scale by tier (20k/50k/80k/110k/150k/200k).
 - Miner batches cost 320k fiat per unit.
 - Each miner piece represents a batch of 50 hydro miners (e.g., Antminer S21 Hydro).
-- Properties and miner batches can be bought with BTC in cycle 2+ at a 10% discount.
+- Properties and miner batches can be bought with BTC at a 10% discount.
 
 ## Owned Property Landing
 - When landing on an owned property, the visitor pays a fiat energy toll.
 - The owner receives a BTC payout for block discovery equal to `base * miner_batches` on that property.
-- Tolls: fiat energy toll = 10% of property price.
+- Tolls: fiat energy toll = 10% of property price + 2.5% of property price per miner batch.
+  - BTC tolls use the same 10% discount as other BTC prices, anchored to base (cycle 1) fiat values.
 
 ## Incidents
 - Landing exactly on a corner incident tile triggers an incident; the tile flip determines bull or bear.
 - The game runs for four cycles; the start tile flip alternates cycle effects:
   - Halving side: base payout is halved for that cycle.
   - Fiat Inflation side: fiat prices and energy tolls inflate by 10% for that cycle.
+  - Inflation persists; once increased, fiat prices do not drop on later halving cycles.
+  - BTC prices remain anchored to base (cycle 1) fiat values.
 
 ## Inspection
 - Landing on Inspection blocks the player's mining payouts.

--- a/godot/scenes/corner_tile.tscn
+++ b/godot/scenes/corner_tile.tscn
@@ -77,12 +77,13 @@ albedo_color = Color(0.05989945, 0.6639494, 1, 1)
 [sub_resource type="BoxMesh" id="BoxMesh_wnpk2"]
 size = Vector3(0.1, 0.01, 0.1)
 
-[node name="CornerTile" type="Node3D" node_paths=PackedStringArray("mesh_root", "top_face", "bottom_face", "side_mesh")]
+[node name="CornerTile" type="Node3D" node_paths=PackedStringArray("mesh_root", "top_face", "bottom_face", "side_mesh", "miner_markers")]
 script = ExtResource("1_4kwbn")
 mesh_root = NodePath("MeshRoot")
 top_face = NodePath("MeshRoot/TopFace")
 bottom_face = NodePath("MeshRoot/BottomFace")
 side_mesh = NodePath("MeshRoot/SideMesh")
+miner_markers = NodePath("MinerMarkers")
 
 [node name="MeshRoot" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.0019139657, 0)
@@ -105,6 +106,8 @@ skeleton = NodePath("")
 surface_material_override/0 = SubResource("StandardMaterial3D_rqfrv")
 
 [node name="PawnMarkers" type="Node3D" parent="."]
+
+[node name="MinerMarkers" type="Node3D" parent="."]
 
 [node name="Marker1" type="Marker3D" parent="PawnMarkers"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0.039)

--- a/godot/scenes/game.tscn
+++ b/godot/scenes/game.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=3 uid="uid://cqmxik86m7jfl"]
+[gd_scene load_steps=14 format=3 uid="uid://cqmxik86m7jfl"]
 
 [ext_resource type="PackedScene" uid="uid://belar34400qbw" path="res://scenes/side_strip.tscn" id="2_s0k7h"]
 [ext_resource type="PackedScene" uid="uid://cf3ptmh3a1lsi" path="res://scenes/player_summary.tscn" id="2_yqjtg"]
@@ -8,7 +8,6 @@
 [ext_resource type="Script" uid="uid://e1pe74jhpbxc" path="res://scripts/game_controller.gd" id="5_77h6y"]
 [ext_resource type="PackedScene" uid="uid://ckbnfxtwa4po5" path="res://scenes/turn_actions.tscn" id="6_p57ef"]
 [ext_resource type="Script" uid="uid://c6s7q4d0p7qrx" path="res://scripts/game_state.gd" id="7_h6e2v"]
-[ext_resource type="Script" path="res://scripts/turn_actions.gd" id="9_0tnpc"]
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_8cj0n"]
 albedo_color = Color(0.05857501, 0.15, 0.0465, 1)
@@ -165,7 +164,6 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 0
-script = ExtResource("9_0tnpc")
 
 [node name="GameIdLabel" type="Label" parent="Control/MarginContainer"]
 unique_name_in_owner = true

--- a/godot/scenes/player_summary.tscn
+++ b/godot/scenes/player_summary.tscn
@@ -68,3 +68,67 @@ layout_mode = 2
 size_flags_horizontal = 3
 text = "0"
 horizontal_alignment = 2
+
+[node name="ViewPropertiesButton" type="Button" parent="VBoxContainer/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "View Properties"
+
+[node name="PropertiesPanel" type="PanelContainer" parent="VBoxContainer/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+
+[node name="PropertiesMargin" type="MarginContainer" parent="VBoxContainer/MarginContainer/VBoxContainer/PropertiesPanel"]
+layout_mode = 2
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="PropertiesContent" type="VBoxContainer" parent="VBoxContainer/MarginContainer/VBoxContainer/PropertiesPanel/PropertiesMargin"]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="PropertiesTitle" type="Label" parent="VBoxContainer/MarginContainer/VBoxContainer/PropertiesPanel/PropertiesMargin/PropertiesContent"]
+layout_mode = 2
+text = "Properties"
+horizontal_alignment = 1
+
+[node name="OrderLockedLabel" type="Label" parent="VBoxContainer/MarginContainer/VBoxContainer/PropertiesPanel/PropertiesMargin/PropertiesContent"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Order locked until end of turn"
+visible = false
+horizontal_alignment = 1
+
+[node name="PropertiesList" type="VBoxContainer" parent="VBoxContainer/MarginContainer/VBoxContainer/PropertiesPanel/PropertiesMargin/PropertiesContent"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_constants/separation = 6
+
+[node name="OrderTotalLabel" type="Label" parent="VBoxContainer/MarginContainer/VBoxContainer/PropertiesPanel/PropertiesMargin/PropertiesContent"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Order Total: 0"
+
+[node name="OrderButtons" type="HBoxContainer" parent="VBoxContainer/MarginContainer/VBoxContainer/PropertiesPanel/PropertiesMargin/PropertiesContent"]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="ConfirmFiatButton" type="Button" parent="VBoxContainer/MarginContainer/VBoxContainer/PropertiesPanel/PropertiesMargin/PropertiesContent/OrderButtons"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Confirm (fiat)"
+
+[node name="ConfirmBtcButton" type="Button" parent="VBoxContainer/MarginContainer/VBoxContainer/PropertiesPanel/PropertiesMargin/PropertiesContent/OrderButtons"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Confirm (btc)"
+
+[node name="ClosePropertiesButton" type="Button" parent="VBoxContainer/MarginContainer/VBoxContainer/PropertiesPanel/PropertiesMargin/PropertiesContent"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Close"

--- a/godot/scenes/tile.tscn
+++ b/godot/scenes/tile.tscn
@@ -12,12 +12,13 @@ size = Vector2(0.1, 0.1)
 [sub_resource type="BoxMesh" id="BoxMesh_uiyn6"]
 size = Vector3(0.1, 0.01, 0.1)
 
-[node name="Tile" type="Node3D" node_paths=PackedStringArray("mesh_root", "top_face", "bottom_face", "side_mesh")]
+[node name="Tile" type="Node3D" node_paths=PackedStringArray("mesh_root", "top_face", "bottom_face", "side_mesh", "miner_markers")]
 script = ExtResource("1_u6qf7")
 mesh_root = NodePath("MeshRoot")
 top_face = NodePath("MeshRoot/TopFace")
 bottom_face = NodePath("MeshRoot/BottomFace")
 side_mesh = NodePath("MeshRoot/HeigthMesh")
+miner_markers = NodePath("MinerMarkers")
 top_material = ExtResource("2_jy7pm")
 bottom_material = ExtResource("3_q7utx")
 
@@ -58,3 +59,18 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.015, 0, 0.045)
 
 [node name="Marker6" type="Marker3D" parent="PawnMarkers"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.015, 0, 0.045)
+
+[node name="MinerMarkers" type="Node3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.012019144, 0.005, 0)
+
+[node name="MinerSlot1" type="Marker3D" parent="MinerMarkers"]
+transform = Transform3D(-0.25881904, 0, -0.9659258, 0, 1, 0, 0.9659258, 0, -0.25881904, 0.008, 0, 0)
+
+[node name="MinerSlot2" type="Marker3D" parent="MinerMarkers"]
+transform = Transform3D(-0.25881904, 0, -0.9659258, 0, 1, 0, 0.9659258, 0, -0.25881904, 0.016, 0, 0)
+
+[node name="MinerSlot3" type="Marker3D" parent="MinerMarkers"]
+transform = Transform3D(-0.25881904, 0, -0.9659258, 0, 1, 0, 0.9659258, 0, -0.25881904, 0, 0, 0)
+
+[node name="MinerSlot4" type="Marker3D" parent="MinerMarkers"]
+transform = Transform3D(-0.25881904, 0, -0.9659258, 0, 1, 0, 0.9659258, 0, -0.25881904, 0.024, 0, 0)

--- a/godot/scripts/autoload/game_config.gd
+++ b/godot/scripts/autoload/game_config.gd
@@ -9,4 +9,4 @@ extends Node
 @export var disable_special_properties: bool = true
 @export var btc_exchange_rate_fiat: float = 100000.0
 @export var game_id: String = ""
-@export var build_id: String = "wlutkokvzusx"
+@export var build_id: String = "zuplrpnunpyz"

--- a/godot/scripts/board_tile.gd
+++ b/godot/scripts/board_tile.gd
@@ -8,6 +8,7 @@ var _top_material: Material
 var _bottom_material: Material
 var _base_mesh_rotation: Vector3
 var _owned_visual: bool = false
+var _miner_instances: Array[Node3D] = []
 
 @export var tile_color: Color = Color.WHITE:
 	get:
@@ -21,6 +22,10 @@ var _owned_visual: bool = false
 @export var top_face: MeshInstance3D
 @export var bottom_face: MeshInstance3D
 @export var side_mesh: MeshInstance3D
+@export var miner_markers: Node3D
+@export var miner_scene: PackedScene = preload("res://meshes/antminer_s21_hydro.tscn")
+
+const MINER_SCALE: float = 0.003
 
 @export var top_material: Material:
 	get:
@@ -43,6 +48,7 @@ func _ready() -> void:
 	assert(top_face)
 	assert(bottom_face)
 	assert(side_mesh)
+	assert(miner_markers)
 	_base_mesh_rotation = mesh_root.rotation
 	_apply_color()
 	_apply_face_materials()
@@ -51,6 +57,23 @@ func _ready() -> void:
 func set_owned_visual(owned: bool) -> void:
 	_owned_visual = owned
 	_apply_owned_visual()
+
+func set_miner_batches(count: int, miner_color: Color) -> void:
+	assert(miner_markers)
+	_clear_miners()
+	if count <= 0:
+		return
+	assert(miner_scene)
+	var slots: Array[Marker3D] = _get_miner_slots()
+	var max_count: int = min(count, slots.size())
+	for index in range(max_count):
+		var slot: Marker3D = slots[index]
+		var instance: Node3D = miner_scene.instantiate() as Node3D
+		assert(instance)
+		instance.scale = Vector3.ONE * MINER_SCALE
+		slot.add_child(instance)
+		_apply_miner_color(instance, miner_color)
+		_miner_instances.append(instance)
 
 func _apply_color() -> void:
 	_color_material.albedo_color = _tile_color
@@ -70,3 +93,55 @@ func _apply_face_materials() -> void:
 func _apply_owned_visual() -> void:
 	var z_offset: float = PI if _owned_visual else 0.0
 	mesh_root.rotation = _base_mesh_rotation + Vector3(0.0, 0.0, z_offset)
+
+func _clear_miners() -> void:
+	for instance in _miner_instances:
+		if instance != null:
+			instance.queue_free()
+	_miner_instances = []
+
+func _get_miner_slots() -> Array[Marker3D]:
+	var slots: Array[Marker3D] = []
+	for child in miner_markers.get_children():
+		var marker: Marker3D = child as Marker3D
+		assert(marker)
+		slots.append(marker)
+	slots.sort_custom(_sort_markers_by_index)
+	return slots
+
+func _sort_markers_by_index(a: Marker3D, b: Marker3D) -> bool:
+	return _extract_marker_index(a.name) < _extract_marker_index(b.name)
+
+func _extract_marker_index(marker_name: String) -> int:
+	var digits: String = ""
+	for i in range(marker_name.length() - 1, -1, -1):
+		var char: String = marker_name.substr(i, 1)
+		if char.is_valid_int():
+			digits = char + digits
+		else:
+			break
+	if digits.is_empty():
+		return 0
+	return int(digits)
+
+func _apply_miner_color(root: Node, miner_color: Color) -> void:
+	for child in root.get_children():
+		if child is MeshInstance3D and child.is_in_group("color_swappable_mesh"):
+			var mesh: MeshInstance3D = child as MeshInstance3D
+			var surface_count: int = mesh.mesh.get_surface_count()
+			for surface in range(surface_count):
+				var material: Material = mesh.get_surface_override_material(surface)
+				if material == null:
+					material = mesh.mesh.surface_get_material(surface)
+				if material == null:
+					continue
+				var material_copy: Material = material.duplicate()
+				mesh.set_surface_override_material(surface, material_copy)
+				if material_copy is StandardMaterial3D:
+					var standard_material: StandardMaterial3D = material_copy as StandardMaterial3D
+					standard_material.albedo_color = miner_color
+				elif material_copy is ShaderMaterial:
+					var shader_material: ShaderMaterial = material_copy as ShaderMaterial
+					if shader_material.get_shader_parameter_list().has("tint_color"):
+						shader_material.set_shader_parameter("tint_color", miner_color)
+		_apply_miner_color(child, miner_color)

--- a/godot/scripts/model_visualizer.gd
+++ b/godot/scripts/model_visualizer.gd
@@ -5,64 +5,64 @@ extends Node3D
 @onready var model_root: Node3D = $ModelRoot
 
 func _ready():
-    # Instance the model scene if not already in the editor
-    if model_scene and model_root.get_child_count() == 0:
-        var instance = model_scene.instantiate()
-        model_root.add_child(instance)
+	# Instance the model scene if not already in the editor
+	if model_scene and model_root.get_child_count() == 0:
+		var instance = model_scene.instantiate()
+		model_root.add_child(instance)
 
-    # After the model is in the tree, set up per-mesh materials
-    call_deferred("_init_swappable_materials")
-    color_picker.color_changed.connect(_on_color_changed)
+	# After the model is in the tree, set up per-mesh materials
+	call_deferred("_init_swappable_materials")
+	color_picker.color_changed.connect(_on_color_changed)
 
 
 func _init_swappable_materials():
-    # For each mesh in the group, duplicate its material so it has its own instance
-    for node in get_tree().get_nodes_in_group("color_swappable_mesh"):
-        if not model_root.is_ancestor_of(node):
-            continue
-        if not (node is MeshInstance3D):
-            continue
+	# For each mesh in the group, duplicate its material so it has its own instance
+	for node in get_tree().get_nodes_in_group("color_swappable_mesh"):
+		if not model_root.is_ancestor_of(node):
+			continue
+		if not (node is MeshInstance3D):
+			continue
 
-        var mesh := node as MeshInstance3D
-        var surface_count := mesh.mesh.get_surface_count()
-        for surface in range(surface_count):
-            var mat := mesh.get_surface_override_material(surface)
-            if mat == null:
-                mat = mesh.mesh.surface_get_material(surface)
-            if mat == null:
-                continue
+		var mesh := node as MeshInstance3D
+		var surface_count := mesh.mesh.get_surface_count()
+		for surface in range(surface_count):
+			var mat := mesh.get_surface_override_material(surface)
+			if mat == null:
+				mat = mesh.mesh.surface_get_material(surface)
+			if mat == null:
+				continue
 
-            # Duplicate material so this mesh has its own copy
-            var mat_copy := mat.duplicate()
-            mesh.set_surface_override_material(surface, mat_copy)
+			# Duplicate material so this mesh has its own copy
+			var mat_copy := mat.duplicate()
+			mesh.set_surface_override_material(surface, mat_copy)
 
-    # Apply initial color
-    _apply_color_to_all_meshes(color_picker.color)
+	# Apply initial color
+	_apply_color_to_all_meshes(color_picker.color)
 
 
 func _on_color_changed(new_color: Color):
-    _apply_color_to_all_meshes(new_color)
+	_apply_color_to_all_meshes(new_color)
 
 
 func _apply_color_to_all_meshes(new_color: Color):
-    for node in get_tree().get_nodes_in_group("color_swappable_mesh"):
-        if not model_root.is_ancestor_of(node):
-            continue
-        if not (node is MeshInstance3D):
-            continue
+	for node in get_tree().get_nodes_in_group("color_swappable_mesh"):
+		if not model_root.is_ancestor_of(node):
+			continue
+		if not (node is MeshInstance3D):
+			continue
 
-        var mesh := node as MeshInstance3D
-        var surface_count := mesh.mesh.get_surface_count()
-        for surface in range(surface_count):
-            var mat := mesh.get_surface_override_material(surface)
-            if mat == null:
-                mat = mesh.mesh.surface_get_material(surface)
-            if mat == null:
-                continue
+		var mesh := node as MeshInstance3D
+		var surface_count := mesh.mesh.get_surface_count()
+		for surface in range(surface_count):
+			var mat := mesh.get_surface_override_material(surface)
+			if mat == null:
+				mat = mesh.mesh.surface_get_material(surface)
+			if mat == null:
+				continue
 
-            if mat is StandardMaterial3D:
-                mat.albedo_color = new_color  # direct color control [web:69][web:64]
-            elif mat is ShaderMaterial:
-                # If you have a custom shader, expose a uniform, e.g. "tint_color"
-                if mat.get_shader_parameter_list().has("tint_color"):
-                    mat.set_shader_parameter("tint_color", new_color)
+			if mat is StandardMaterial3D:
+				mat.albedo_color = new_color  # direct color control [web:69][web:64]
+			elif mat is ShaderMaterial:
+				# If you have a custom shader, expose a uniform, e.g. "tint_color"
+				if mat.get_shader_parameter_list().has("tint_color"):
+					mat.set_shader_parameter("tint_color", new_color)

--- a/godot/scripts/number_format.gd
+++ b/godot/scripts/number_format.gd
@@ -6,11 +6,11 @@ static func format_fiat(value: float) -> String:
 	var parts: PackedStringArray = text.split(".")
 	var integer_part: String = parts[0]
 	var fractional: String = parts[1] if parts.size() > 1 else "00"
-	var sign: String = ""
+	var sign_text: String = ""
 	if integer_part.begins_with("-"):
-		sign = "-"
+		sign_text = "-"
 		integer_part = integer_part.substr(1, integer_part.length() - 1)
-	return "%s%s.%s" % [sign, _format_with_commas(integer_part), fractional]
+	return "%s%s.%s" % [sign_text, _format_with_commas(integer_part), fractional]
 
 static func format_btc(value: float) -> String:
 	return "%.4f" % value

--- a/godot/scripts/player_summary.gd
+++ b/godot/scripts/player_summary.gd
@@ -5,21 +5,57 @@ extends FoldableContainer
 @onready var fiat_balance_label: Label = %FiatBalanceLabel
 @onready var bitcoin_balance_label: Label = %BitcoinBalanceLabel
 @onready var mining_power_label: Label = %MiningPowerLabel
+@onready var view_properties_button: Button = %ViewPropertiesButton
+@onready var properties_panel: PanelContainer = %PropertiesPanel
+@onready var properties_list: VBoxContainer = %PropertiesList
+@onready var order_total_label: Label = %OrderTotalLabel
+@onready var confirm_fiat_button: Button = %ConfirmFiatButton
+@onready var confirm_btc_button: Button = %ConfirmBtcButton
+@onready var close_properties_button: Button = %ClosePropertiesButton
+@onready var order_locked_label: Label = %OrderLockedLabel
+
+var _game_state: GameState
+var _order_counts: Dictionary = {}
+var _can_edit_order: bool = true
 
 func _ready() -> void:
 	assert(fiat_balance_label)
 	assert(bitcoin_balance_label)
 	assert(mining_power_label)
+	assert(view_properties_button)
+	assert(properties_panel)
+	assert(properties_list)
+	assert(order_total_label)
+	assert(confirm_fiat_button)
+	assert(confirm_btc_button)
+	assert(close_properties_button)
+	assert(order_locked_label)
 	_apply_title_panel_style(Palette.get_player_dark(player_index))
 	
 	# set panel title based on player index
 	self.title = "Player %d" % [player_index + 1]
+	if not view_properties_button.pressed.is_connected(_on_view_properties_pressed):
+		view_properties_button.pressed.connect(_on_view_properties_pressed)
+	if not confirm_fiat_button.pressed.is_connected(_on_confirm_fiat_pressed):
+		confirm_fiat_button.pressed.connect(_on_confirm_fiat_pressed)
+	if not confirm_btc_button.pressed.is_connected(_on_confirm_btc_pressed):
+		confirm_btc_button.pressed.connect(_on_confirm_btc_pressed)
+	if not close_properties_button.pressed.is_connected(_on_close_properties_pressed):
+		close_properties_button.pressed.connect(_on_close_properties_pressed)
 
 func set_player_data(player_data: PlayerData) -> void:
 	assert(player_data)
 	set_fiat_balance(player_data.fiat_balance)
 	set_bitcoin_balance(player_data.bitcoin_balance)
 	set_mining_power(player_data.mining_power)
+
+func set_game_state(game_state: GameState) -> void:
+	assert(game_state)
+	_game_state = game_state
+	if not _game_state.miner_order_committed.is_connected(_on_miner_order_committed):
+		_game_state.miner_order_committed.connect(_on_miner_order_committed)
+	if not _game_state.miner_order_locked.is_connected(_on_miner_order_locked):
+		_game_state.miner_order_locked.connect(_on_miner_order_locked)
 
 func set_fiat_balance(balance: float) -> void:
 	assert(fiat_balance_label)
@@ -32,6 +68,152 @@ func set_bitcoin_balance(balance: float) -> void:
 func set_mining_power(power: int) -> void:
 	assert(mining_power_label)
 	mining_power_label.text = str(power)
+
+func _on_view_properties_pressed() -> void:
+	properties_panel.visible = not properties_panel.visible
+	if properties_panel.visible:
+		_refresh_properties_view()
+
+func _on_close_properties_pressed() -> void:
+	properties_panel.visible = false
+
+func _on_confirm_fiat_pressed() -> void:
+	_confirm_order(false)
+
+func _on_confirm_btc_pressed() -> void:
+	_confirm_order(true)
+
+func _confirm_order(use_bitcoin: bool) -> void:
+	assert(_game_state)
+	if not _can_edit_order:
+		return
+	var order: Dictionary = {}
+	for tile_index in _order_counts.keys():
+		var count: int = int(_order_counts[tile_index])
+		if count > 0:
+			order[tile_index] = count
+	var did_set: bool = _game_state.set_pending_miner_order(player_index, order, use_bitcoin)
+	if did_set:
+		_refresh_properties_view()
+
+func _refresh_properties_view() -> void:
+	assert(_game_state)
+	_clear_property_list()
+	_order_counts = {}
+	var owned_tiles: Array[int] = _game_state.get_owned_property_indices(player_index)
+	_can_edit_order = _game_state.can_place_miner_order(player_index)
+	order_locked_label.visible = not _can_edit_order
+	if owned_tiles.is_empty():
+		var empty_label: Label = Label.new()
+		empty_label.text = "No properties yet"
+		properties_list.add_child(empty_label)
+		_update_order_total()
+		_update_confirm_buttons()
+		return
+	var pending_order: Dictionary = _game_state.get_pending_miner_order(player_index)
+	for tile_index in owned_tiles:
+		_add_property_row(tile_index, pending_order)
+	_update_order_total()
+	_update_confirm_buttons()
+
+func _add_property_row(tile_index: int, pending_order: Dictionary) -> void:
+	var tile: TileInfo = _game_state.get_tile_info(tile_index)
+	var row: HBoxContainer = HBoxContainer.new()
+	row.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	row.add_theme_constant_override("separation", 8)
+
+	var texture_rect: TextureRect = TextureRect.new()
+	texture_rect.custom_minimum_size = Vector2(48, 48)
+	texture_rect.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+	var image_path: String = _get_city_image_path(tile.city)
+	if not image_path.is_empty():
+		texture_rect.texture = load(image_path)
+	row.add_child(texture_rect)
+
+	var info_label: Label = Label.new()
+	info_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	var pending_count: int = int(pending_order.get(tile_index, 0))
+	if _can_edit_order:
+		info_label.text = "%s\nMiners: %d" % [tile.city, tile.miner_batches]
+	else:
+		info_label.text = "%s\nMiners: %d (+%d pending)" % [tile.city, tile.miner_batches, pending_count]
+	row.add_child(info_label)
+
+	var spinner: SpinBox = SpinBox.new()
+	spinner.step = 1.0
+	spinner.min_value = 0.0
+	var max_additional: int = GameState.MAX_MINER_BATCHES_PER_PROPERTY - tile.miner_batches
+	if max_additional < 0:
+		max_additional = 0
+	spinner.max_value = float(max_additional)
+	spinner.value = float(pending_count if not _can_edit_order else 0)
+	spinner.editable = _can_edit_order
+	spinner.size_flags_horizontal = Control.SIZE_SHRINK_CENTER
+	if _can_edit_order:
+		spinner.value_changed.connect(_on_spinner_changed.bind(tile_index))
+	_order_counts[tile_index] = int(spinner.value)
+	row.add_child(spinner)
+
+	properties_list.add_child(row)
+
+func _on_spinner_changed(value: float, tile_index: int) -> void:
+	_order_counts[tile_index] = int(value)
+	_update_order_total()
+	_update_confirm_buttons()
+
+func _update_order_total() -> void:
+	assert(_game_state)
+	var total_batches: int = 0
+	for count in _order_counts.values():
+		total_batches += int(count)
+	var total_fiat: float = float(total_batches) * _game_state.get_miner_batch_price_fiat()
+	var total_btc: float = float(total_batches) * _game_state.get_miner_batch_price_btc()
+	order_total_label.text = "Order Total: %s fiat | %s BTC" % [
+		NumberFormat.format_fiat(total_fiat),
+		NumberFormat.format_btc(total_btc),
+	]
+
+func _update_confirm_buttons() -> void:
+	var total_batches: int = 0
+	for count in _order_counts.values():
+		total_batches += int(count)
+	var disabled: bool = total_batches == 0 or not _can_edit_order
+	confirm_fiat_button.disabled = disabled
+	confirm_btc_button.disabled = disabled
+
+func _clear_property_list() -> void:
+	for child in properties_list.get_children():
+		properties_list.remove_child(child)
+		child.queue_free()
+
+func _get_city_image_path(city: String) -> String:
+	match city:
+		"Caracas":
+			return "res://textures/1-caracas-without-mining.png"
+		"Assuncion":
+			return "res://textures/2-assuncion-without-mining.png"
+		"Ciudad del Este":
+			return "res://textures/3-ciudad-del-este-without-mining.png"
+		"Minsk":
+			return "res://textures/4-minsk-without-mining.png"
+		"Irkutsk":
+			return "res://textures/5-irkutsk-without-mining.png"
+		"Rockdale":
+			return "res://textures/6-rockdale-without-mining.png"
+		_:
+			return ""
+
+func _on_miner_order_committed(committed_player_index: int) -> void:
+	if committed_player_index != player_index:
+		return
+	if properties_panel.visible:
+		_refresh_properties_view()
+
+func _on_miner_order_locked(locked_player_index: int, _locked: bool) -> void:
+	if locked_player_index != player_index:
+		return
+	if properties_panel.visible:
+		_refresh_properties_view()
 
 
 func _apply_title_panel_style(dark_color: Color) -> void:

--- a/godot/scripts/tile_info.gd
+++ b/godot/scripts/tile_info.gd
@@ -9,6 +9,7 @@ var property_price: float
 var special_property_name: String
 var special_property_price: float
 var owner_index: int
+var miner_batches: int
 
 func _init() -> void:
 	tile_type = "unknown"
@@ -19,3 +20,4 @@ func _init() -> void:
 	special_property_name = ""
 	special_property_price = 0.0
 	owner_index = -1
+	miner_batches = 0

--- a/godot/scripts/turn_actions.gd
+++ b/godot/scripts/turn_actions.gd
@@ -211,6 +211,7 @@ func update_tile_info(
 	toll_btc: float,
 	payout_cycle_1_2: float,
 	payout_cycle_3_4: float,
+	miner_batches: int,
 	is_owned: bool,
 	owner_name: String,
 	buy_visible: bool,
@@ -224,7 +225,7 @@ func update_tile_info(
 		_update_property_image(city, is_owned)
 		_update_price_label(tile_type, property_price, special_price, bitcoin_price)
 		_update_owner_label(is_owned, owner_name)
-		_update_toll_label(toll_fiat, toll_btc)
+		_update_toll_label(toll_fiat, toll_btc, miner_batches)
 		_update_payout_label(payout_cycle_1_2, payout_cycle_3_4)
 		_update_buy_buttons(
 			buy_visible,
@@ -319,9 +320,12 @@ func _update_buy_buttons(buy_visible: bool, buy_fiat_enabled: bool, buy_btc_enab
 	buy_fiat_button.disabled = not buy_fiat_enabled
 	buy_bitcoin_button.disabled = not buy_btc_enabled
 
-func _update_toll_label(toll_fiat: float, toll_btc: float) -> void:
+func _update_toll_label(toll_fiat: float, toll_btc: float, miner_batches: int) -> void:
 	assert(toll_label)
-	toll_label.text = "Energy Toll\nFiat: %s\nBTC: %s" % [
+	var batch_label: String = "batch" if miner_batches == 1 else "batches"
+	toll_label.text = "Energy Toll (%d miner %s)\nFiat: %s\nBTC: %s" % [
+		miner_batches,
+		batch_label,
 		NumberFormat.format_fiat(toll_fiat),
 		NumberFormat.format_btc(toll_btc),
 	]


### PR DESCRIPTION
Adds a player-summary properties panel to stage miner batch purchases, confirms orders in fiat or BTC, and locks inputs until orders settle. Tracks miner batches per tile, applies orders each turn end, and emits updates to drive board visuals. Spawns and colors miner meshes using per-tile markers, removes placeholder miner children, and updates toll math to scale with miner batches while keeping BTC prices anchored to base values. Fixes state wiring for summaries and cleans up warning-level naming issues.