### PR TITLE
feat: fast-forward turn visuals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,10 @@ the source of truth for project constraints while working in this repo.
 - Balance and rules data live in GDScript constants (for now).
 - English-only content for this milestone.
 
+## Rules Source of Truth
+
+- Treat `docs/bitcoin-mining-game-design.md` as the canonical game rules/manual.
+
 ## Current Milestone: Offline Game Loop v0
 
 Done means:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Offline UI slice for the Evanopolis tabletop game. This repo focuses on a playab
 ## Notes
 
 - See `docs/spec.md` for the current ruleset.
+- See `docs/bitcoin-mining-game-design.md` for the canonical game rules/manual.
 - See `docs/ai-context.md` for offline demo scope + rules clarifications.
 - See `docs/color-spec.md` for pawn color pairs and usage.
 - See `docs/runbook.md` for playtest steps.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,10 @@
+# TODO
+
+## Tile Flip Rules (Not Implemented)
+
+- Start tile flip on pass-over to begin a new cycle (Start ↔ Fiat Inflation).
+- Bear tile flip on pass-over to change the effect for the next landing (Bear ↔ Bull).
+
+## UI Cleanup
+
+- Remove dual-currency payment options (fiat/bitcoin) from the game UI.

--- a/godot/scripts/autoload/game_config.gd
+++ b/godot/scripts/autoload/game_config.gd
@@ -9,4 +9,4 @@ extends Node
 @export var disable_special_properties: bool = true
 @export var btc_exchange_rate_fiat: float = 100000.0
 @export var game_id: String = ""
-@export var build_id: String = "kkrrunymoplx"
+@export var build_id: String = "zuouzqpkloyq"

--- a/godot/scripts/camera_tile_rig.gd
+++ b/godot/scripts/camera_tile_rig.gd
@@ -150,12 +150,10 @@ func _bind_game_controller() -> void:
 		game_controller.turn_started.connect(_on_turn_started)
 
 func _on_dice_roll_started(start_tile_index: int, end_tile_index: int, player_index: int) -> void:
+	_cancel_dice_camera_sequence()
 	var pawn: Node3D = _get_pawn(player_index)
 	start_follow(pawn)
-	_dice_camera_token += 1
 	var token: int = _dice_camera_token
-	if _dice_camera_timer:
-		_dice_camera_timer = null
 	var board_tiles: Array = board_layout.get_board_tiles()
 	var board_size: int = board_tiles.size()
 	var steps: int = (end_tile_index - start_tile_index + board_size) % board_size
@@ -187,11 +185,13 @@ func _finish_dice_roll_camera_transition(end_tile_index: int, token: int) -> voi
 	set_zoom(true)
 
 func _on_turn_ended(_next_player_index: int, _next_tile_index: int) -> void:
+	_cancel_dice_camera_sequence()
 	stop_follow()
 	snap_to_tile(_next_tile_index, _next_player_index)
 	set_zoom(false)
 
 func _on_turn_started(player_index: int, tile_index: int) -> void:
+	_cancel_dice_camera_sequence()
 	stop_follow()
 	snap_to_tile(tile_index, player_index)
 	set_zoom(false)
@@ -229,3 +229,11 @@ func _set_base_transform(value: Transform3D) -> void:
 func _set_zoom_blend(value: float) -> void:
 	_zoom_blend = value
 	_apply_composed_transform()
+
+func _cancel_dice_camera_sequence() -> void:
+	_dice_camera_token += 1
+	if _dice_camera_timer:
+		_dice_camera_timer = null
+	if _fov_tween:
+		_fov_tween.kill()
+		_fov_tween = null


### PR DESCRIPTION
Cancel in-flight pawn/camera transitions and snap to end state on end turn. Document the canonical rules source and missing tile flip tasks; add UI cleanup TODO. Sync build id for the current change.