### PR TITLE
fix: keep player properties synced

### DIFF
--- a/godot/scenes/game.tscn
+++ b/godot/scenes/game.tscn
@@ -86,6 +86,7 @@ mesh = SubResource("BoxMesh_0tnpc")
 
 [node name="CameraPoseRig" type="Node3D" parent="Environment"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.3524459, 0, 0)
+visible = false
 
 [node name="TileRef" parent="Environment/CameraPoseRig" instance=ExtResource("1_tile")]
 
@@ -199,6 +200,7 @@ player_index = 3
 [node name="Player  Summary 5" parent="Control/MarginContainer/BoxContainer/PlayersList/VBoxContainer" instance=ExtResource("2_yqjtg")]
 layout_mode = 2
 player_index = 4
+
 
 [node name="Player  Summary 6" parent="Control/MarginContainer/BoxContainer/PlayersList/VBoxContainer" instance=ExtResource("2_yqjtg")]
 layout_mode = 2

--- a/godot/scenes/player_summary.tscn
+++ b/godot/scenes/player_summary.tscn
@@ -10,7 +10,7 @@ title = "Player 1"
 script = ExtResource("1_d6wb6")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
-visible = false
+visible = true
 layout_mode = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer"]
@@ -69,14 +69,9 @@ size_flags_horizontal = 3
 text = "0"
 horizontal_alignment = 2
 
-[node name="ViewPropertiesButton" type="Button" parent="VBoxContainer/MarginContainer/VBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-text = "View Properties"
-
 [node name="PropertiesPanel" type="PanelContainer" parent="VBoxContainer/MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
-visible = false
+visible = true
 layout_mode = 2
 
 [node name="PropertiesMargin" type="MarginContainer" parent="VBoxContainer/MarginContainer/VBoxContainer/PropertiesPanel"]
@@ -126,8 +121,3 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Confirm"
-
-[node name="ClosePropertiesButton" type="Button" parent="VBoxContainer/MarginContainer/VBoxContainer/PropertiesPanel/PropertiesMargin/PropertiesContent"]
-unique_name_in_owner = true
-layout_mode = 2
-text = "Close"

--- a/godot/scripts/autoload/game_config.gd
+++ b/godot/scripts/autoload/game_config.gd
@@ -9,4 +9,4 @@ extends Node
 @export var disable_special_properties: bool = true
 @export var btc_exchange_rate_fiat: float = 100000.0
 @export var game_id: String = ""
-@export var build_id: String = "qlmzzmzwrumo"
+@export var build_id: String = "oqlxuxsvunln"

--- a/godot/scripts/game_state.gd
+++ b/godot/scripts/game_state.gd
@@ -40,6 +40,8 @@ signal turn_state_changed(player_index: int, turn_number: int, cycle_number: int
 signal miner_order_locked(player_index: int, locked: bool)
 signal miner_order_committed(player_index: int)
 signal miner_batches_changed(tile_index: int, miner_batches: int, owner_index: int)
+signal property_owner_changed(tile_index: int, owner_index: int)
+signal state_reset()
 
 func _ready() -> void:
 	seed(GameConfig.game_id.hash())
@@ -90,6 +92,7 @@ func reset_positions() -> void:
 	current_cycle = 1
 	turn_count = 1
 	_emit_turn_state()
+	state_reset.emit()
 
 func advance_turn() -> void:
 	current_player_index = (current_player_index + 1) % GameConfig.player_count
@@ -303,6 +306,7 @@ func purchase_tile(player_index: int, tile_index: int, use_bitcoin: bool) -> boo
 		player_data.fiat_balance -= price
 	player_data_changed.emit(player_index, player_data)
 	tile.owner_index = player_index
+	property_owner_changed.emit(tile_index, player_index)
 	return true
 
 func _build_tile_info() -> void:

--- a/godot/scripts/player_summary.gd
+++ b/godot/scripts/player_summary.gd
@@ -5,12 +5,10 @@ extends FoldableContainer
 @onready var fiat_balance_label: Label = %FiatBalanceLabel
 @onready var bitcoin_balance_label: Label = %BitcoinBalanceLabel
 @onready var mining_power_label: Label = %MiningPowerLabel
-@onready var view_properties_button: Button = %ViewPropertiesButton
 @onready var properties_panel: PanelContainer = %PropertiesPanel
 @onready var properties_list: VBoxContainer = %PropertiesList
 @onready var order_total_fiat_label: Label = %OrderTotalFiatLabel
 @onready var confirm_fiat_button: Button = %ConfirmFiatButton
-@onready var close_properties_button: Button = %ClosePropertiesButton
 @onready var order_locked_label: Label = %OrderLockedLabel
 
 var _game_state: GameState
@@ -21,23 +19,17 @@ func _ready() -> void:
 	assert(fiat_balance_label)
 	assert(bitcoin_balance_label)
 	assert(mining_power_label)
-	assert(view_properties_button)
 	assert(properties_panel)
 	assert(properties_list)
 	assert(order_total_fiat_label)
 	assert(confirm_fiat_button)
-	assert(close_properties_button)
 	assert(order_locked_label)
 	_apply_title_panel_style(Palette.get_player_dark(player_index))
 	
 	# set panel title based on player index
 	self.title = "Player %d" % [player_index + 1]
-	if not view_properties_button.pressed.is_connected(_on_view_properties_pressed):
-		view_properties_button.pressed.connect(_on_view_properties_pressed)
 	if not confirm_fiat_button.pressed.is_connected(_on_confirm_fiat_pressed):
 		confirm_fiat_button.pressed.connect(_on_confirm_fiat_pressed)
-	if not close_properties_button.pressed.is_connected(_on_close_properties_pressed):
-		close_properties_button.pressed.connect(_on_close_properties_pressed)
 
 func set_player_data(player_data: PlayerData) -> void:
 	assert(player_data)
@@ -54,6 +46,10 @@ func set_game_state(game_state: GameState) -> void:
 		_game_state.miner_order_committed.connect(_on_miner_order_committed)
 	if not _game_state.miner_order_locked.is_connected(_on_miner_order_locked):
 		_game_state.miner_order_locked.connect(_on_miner_order_locked)
+	if not _game_state.property_owner_changed.is_connected(_on_property_owner_changed):
+		_game_state.property_owner_changed.connect(_on_property_owner_changed)
+	if not _game_state.state_reset.is_connected(_on_state_reset):
+		_game_state.state_reset.connect(_on_state_reset)
 
 func set_fiat_balance(balance: float) -> void:
 	assert(fiat_balance_label)
@@ -66,14 +62,6 @@ func set_bitcoin_balance(balance: float) -> void:
 func set_mining_power(power: int) -> void:
 	assert(mining_power_label)
 	mining_power_label.text = str(power)
-
-func _on_view_properties_pressed() -> void:
-	properties_panel.visible = not properties_panel.visible
-	if properties_panel.visible:
-		_refresh_properties_view()
-
-func _on_close_properties_pressed() -> void:
-	properties_panel.visible = false
 
 func _on_confirm_fiat_pressed() -> void:
 	_confirm_order()
@@ -228,6 +216,16 @@ func _on_miner_order_committed(committed_player_index: int) -> void:
 func _on_miner_order_locked(locked_player_index: int, _locked: bool) -> void:
 	if locked_player_index != player_index:
 		return
+	if properties_panel.visible:
+		_refresh_properties_view()
+
+func _on_property_owner_changed(tile_index: int, owner_index: int) -> void:
+	if owner_index != player_index:
+		return
+	if properties_panel.visible:
+		_refresh_properties_view()
+
+func _on_state_reset() -> void:
 	if properties_panel.visible:
 		_refresh_properties_view()
 


### PR DESCRIPTION
Always show the properties panel and refresh it when state resets or ownership changes, and only bind summaries for active players.